### PR TITLE
sort messages so that sub-messages are defined first

### DIFF
--- a/src/fastpb/generator.py
+++ b/src/fastpb/generator.py
@@ -33,8 +33,12 @@ TYPE = {
   'STRING': descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
   'DOUBLE': descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE,
   'INT32': descriptor_pb2.FieldDescriptorProto.TYPE_INT32,
+  'SINT32': descriptor_pb2.FieldDescriptorProto.TYPE_SINT32,
+  'UINT32': descriptor_pb2.FieldDescriptorProto.TYPE_UINT32,
   'INT64': descriptor_pb2.FieldDescriptorProto.TYPE_INT64,
-  'MESSAGE': descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE
+  'SINT64': descriptor_pb2.FieldDescriptorProto.TYPE_SINT64,
+  'MESSAGE': descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+  'BYTES': descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
   # TODO(robbyw): More types.
 }
 

--- a/src/fastpb/generator.py
+++ b/src/fastpb/generator.py
@@ -19,6 +19,7 @@
 import plugin_pb2
 
 from google.protobuf import descriptor_pb2
+from fastpb.util import order_dependencies
 from jinja2 import Template
 
 # pylint: disable=E0611
@@ -53,14 +54,34 @@ def template(name):
   return Template(resource_string(__name__, 'template/' + name))
 
 
+def sort_messages(moduleName, messages):
+    # sort messages so that sub-messages are defined first
+    # to avoid compile errors: XXX was not declared in this scope
+    dependencies = []
+    msg_dict = {}
+    for msg in messages:
+        msg_name = '.' + moduleName + '.' + msg.name
+        msg_dict[msg_name] = msg
+        deps = set()
+        for member in msg.field:
+            if member.type == TYPE['MESSAGE']:
+                deps.add(member.type_name)
+        dependencies.append((msg_name, deps))
+    
+    sorted_msg_names = order_dependencies(dependencies)
+    ordered_msgs = [msg_dict[n] for n in sorted_msg_names]
+    return ordered_msgs
+
+
 def writeCFile(response, name, fileObject):
   """Writes a C file."""
+  messages = sort_messages(fileObject.package, fileObject.message_type)
   context = {
     'fileName': name,
     'moduleName': fileObject.package.lstrip('.'),
     'package': fileObject.package.replace('.', '::'),
     'packageName': fileObject.package.split('.')[-1],
-    'messages': fileObject.message_type,
+    'messages': messages,
     'enums': fileObject.enum_type,
     'TYPE': TYPE,
     'LABEL': LABEL

--- a/src/fastpb/template/module.jinjacc
+++ b/src/fastpb/template/module.jinjacc
@@ -5,13 +5,13 @@
 
 
 static PyObject *
-fastpb_convert{{ TYPE.INT64 }}(::google::protobuf::int32 value)
+fastpb_convert{{ TYPE.INT32 }}(::google::protobuf::int32 value)
 {
     return PyLong_FromLong(value);
 }
 
 static PyObject *
-fastpb_convert{{ TYPE.INT32 }}(::google::protobuf::int64 value)
+fastpb_convert{{ TYPE.INT64 }}(::google::protobuf::int64 value)
 {
     return PyLong_FromLongLong(value);
 }

--- a/src/fastpb/template/module.jinjacc
+++ b/src/fastpb/template/module.jinjacc
@@ -17,6 +17,24 @@ fastpb_convert{{ TYPE.INT64 }}(::google::protobuf::int64 value)
 }
 
 static PyObject *
+fastpb_convert{{ TYPE.SINT64 }}(::google::protobuf::int64 value)
+{
+    return PyLong_FromLongLong(value);
+}
+
+static PyObject *
+fastpb_convert{{ TYPE.SINT32 }}(::google::protobuf::int32 value)
+{
+    return PyLong_FromLong(value);
+}
+
+static PyObject *
+fastpb_convert{{ TYPE.UINT32 }}(::google::protobuf::uint32 value)
+{
+    return PyLong_FromUnsignedLong(value);
+}
+
+static PyObject *
 fastpb_convert{{ TYPE.DOUBLE }}(double value)
 {
     return PyFloat_FromDouble(value);
@@ -26,6 +44,12 @@ static PyObject *
 fastpb_convert{{ TYPE.STRING }}(const ::std::string &value)
 {
     return PyUnicode_Decode(value.data(), value.length(), "utf-8", NULL);
+}
+
+static PyObject *
+fastpb_convert{{ TYPE.BYTES }}(const ::std::string &value)
+{
+    return PyString_FromStringAndSize(value.data(), value.length());
 }
 
 {% for message in messages %}
@@ -148,6 +172,15 @@ fastpb_convert{{ TYPE.STRING }}(const ::std::string &value)
 
         std::string protoValue(PyString_AsString(value), PyString_Size(value));
 
+      {% elif member.type == TYPE.BYTES %}
+        // string
+        if (! PyString_Check(value)) {
+          PyErr_SetString(PyExc_TypeError, "The {{ member.name }} attribute value must be a string");
+          return -1;
+        }
+
+        std::string protoValue(PyString_AsString(value), PyString_Size(value));
+
       {% elif member.type == TYPE.DOUBLE %}
         // double
         double protoValue;
@@ -163,7 +196,7 @@ fastpb_convert{{ TYPE.STRING }}(const ::std::string &value)
           return -1;
         }
 
-      {% elif member.type == TYPE.INT64 %}
+      {% elif member.type == TYPE.INT64 or member.type == TYPE.SINT64 %}
         ::google::protobuf::int64 protoValue;
 
         // int64
@@ -177,12 +210,26 @@ fastpb_convert{{ TYPE.STRING }}(const ::std::string &value)
           return -1;
         }
 
-      {% elif member.type == TYPE.INT32 %}
+      {% elif member.type == TYPE.INT32 or member.type == TYPE.SINT32 %}
         ::google::protobuf::int32 protoValue;
 
         // int32
         if (PyInt_Check(value)) {
           protoValue = PyInt_AsLong(value);
+        } else {
+          PyErr_SetString(PyExc_TypeError,
+                          "The {{ member.name }} attribute value must be an integer");
+          return -1;
+        }
+        
+      {% elif member.type == TYPE.UINT32 %}
+        ::google::protobuf::uint32 protoValue;
+
+        // uint32
+        if (PyInt_Check(value)) {
+          protoValue = PyInt_AsUnsignedLongMask(value);
+        } else if (PyLong_Check(value)) {
+          protoValue = PyLong_AsUnsignedLong(value);
         } else {
           PyErr_SetString(PyExc_TypeError,
                           "The {{ member.name }} attribute value must be an integer");

--- a/src/fastpb/util.py
+++ b/src/fastpb/util.py
@@ -1,0 +1,88 @@
+# Copyright 2011 The fast-python-pb Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # just ignore the order with Python <2.7 for now
+    OrderedDict = dict
+
+def order_dependencies(dependencies):
+    depends_on = OrderedDict()
+    dependent_off = defaultdict(set)
+    
+    for item, deps in dependencies:
+        depends_on[item] = set()
+        for dep in deps:
+            dependent_off[dep].add(item)
+            depends_on[item].add(dep)
+    
+    result = []
+    while depends_on:
+        # collect items wihout any dependencies
+        for item, dependens in depends_on.iteritems():
+            if not dependens: # item without dependencies
+                result.append(item)
+                del depends_on[item]
+                if item in dependent_off:
+                    # item resolved -> remove from dependents
+                    for dependents in dependent_off[item]:
+                        depends_on[dependents].remove(item)
+                break # start again to keep general order of dependencies
+        else:
+            assert False, 'recursive dependency detected'
+
+    return result
+
+class TestOrderDependencies(object):
+    def test_tree(self):
+        tree = [
+            ('a', ('b', 'c')),
+            ('b', ('c', )),
+            ('c', ()),
+        ]
+        assert order_dependencies(tree) == ['c', 'b', 'a']
+    
+    def test_flat(self):
+        tree = [
+            ('a', ()),
+            ('b', ()),
+            ('c', ()),
+        ]
+        assert order_dependencies(tree) == ['a', 'b', 'c']
+    
+    def test_diamond(self):
+        tree = [
+            ('a', ('b', 'c')),
+            ('b', ('d',)),
+            ('c', ('d',)),
+            ('d', ()),
+        ]
+        assert order_dependencies(tree) == ['d', 'b', 'c', 'a']
+
+    def test_loop(self):
+        tree = [
+            ('a', ('b')),
+            ('b', ('c',)),
+            ('c', ('a',)),
+        ]
+        try:
+            order_dependencies(tree)
+        except AssertionError:
+            pass
+        else:
+            assert False, 'assertion expected'
+


### PR DESCRIPTION
C is picky about the order the functions(messages) are defined (unlike Java and Python), so there are unordered .proto files out there. Added code to sort the dependencies between the messages.
